### PR TITLE
Add Dependabot Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore
+    labels: [chore]


### PR DESCRIPTION
This pull request simply adds a new [Dependabot](https://docs.github.com/en/code-security/dependabot) configuration that checks for new updates of GitHub Actions dependencies. It closes #8.